### PR TITLE
The inheritance of attribute options is broken

### DIFF
--- a/lib/MooX/Aliases.pm
+++ b/lib/MooX/Aliases.pm
@@ -35,11 +35,12 @@ sub import {
   my %init_args;
   install_modifier $target, 'around', 'has', sub {
     my $orig = shift;
-    my ($attr, %opts) = @_;
+    my ($attr_proto, %opts) = @_;
+    my $attr = $attr_proto;
     $attr =~ s/^\+//;
 
     my $aliases = delete $opts{alias};
-    return $orig->($attr, %opts)
+    return $orig->($attr_proto, %opts)
       unless $aliases;
 
     $aliases = [ $aliases ]
@@ -52,7 +53,7 @@ sub import {
     }
     $init_args{$name} = \@names;
 
-    my $out = $orig->($attr, %opts);
+    my $out = $orig->($attr_proto, %opts);
 
     for my $alias (@$aliases) {
       $make_alias->($alias => $attr);

--- a/lib/MooX/Aliases.pm
+++ b/lib/MooX/Aliases.pm
@@ -36,12 +36,22 @@ sub import {
   install_modifier $target, 'around', 'has', sub {
     my $orig = shift;
     my ($attr_proto, %opts) = @_;
-    my $attr = $attr_proto;
-    $attr =~ s/^\+//;
 
     my $aliases = delete $opts{alias};
     return $orig->($attr_proto, %opts)
       unless $aliases;
+
+    my $attr_ref = ref $attr_proto;
+
+    if ($attr_ref eq 'ARRAY') {
+        croak "Cannot alias list of attributes";
+    }
+
+    return $orig->($attr_proto, %opts)
+      if $attr_ref;
+
+    my $attr = $attr_proto;
+    $attr =~ s/^\+//;
 
     $aliases = [ $aliases ]
       if !ref $aliases;

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -1,5 +1,6 @@
 use strictures 1;
 use Test::More;
+use Test::Fatal;
 
 my ($foo_called, $baz_called, $override_called);
 
@@ -23,6 +24,14 @@ my ($foo_called, $baz_called, $override_called);
     has wark => (
         is      => 'rw',
     );
+
+    ::like( ::exception {
+        has [qw(attr1 attr2)] => (
+            is    => 'rw',
+            alias => 'attr3',
+        )
+    }, qr/^Cannot alias list of attributes/,
+        "aliasing a list of attributes");
 
     package MyTest::Sub;
     use Moo;

--- a/t/attributes.t
+++ b/t/attributes.t
@@ -30,7 +30,6 @@ my ($foo_called, $baz_called, $override_called);
 
     extends qw(MyTest);
     has '+foo' => (
-        is      => 'rw',
         alias   => 'override',
         trigger => sub { $override_called++ },
     );


### PR DESCRIPTION
This example raises `Must have an is at...` exception because `is => 'rw'` from `Foo::foo` is not inherited:

``` perl
package Foo;

use Moo;

has foo => (
    is => 'rw',
);

package Bar;

use Moo;
use MooX::Aliases;

extends 'Foo';

has '+foo' => (
    alias => 'bar',
);
```
